### PR TITLE
Fixed wire format types to align with protobuf documentation.

### DIFF
--- a/protobuf/message/encoding.odin
+++ b/protobuf/message/encoding.odin
@@ -117,7 +117,7 @@ encode_field_map :: proc(field_info: Field_Info) -> (field: wire.Field, ok: bool
 		allocator = context.temp_allocator,
 	)
 
-	entry_fields := make_map(
+	entry_fields := make_map_cap(
 		map[u32]wire.Field,
 		capacity = 2,
 		allocator = context.temp_allocator,

--- a/protobuf/message/types.odin
+++ b/protobuf/message/types.odin
@@ -153,7 +153,7 @@ is_packed :: proc(field_info: Field_Info) -> bool {
 struct_field_count :: proc(message: any) -> (count: int, ok: bool) {
 	ti := runtime.type_info_base(type_info_of(message.id))
 	s := ti.variant.(runtime.Type_Info_Struct) or_return
-	return len(s.names), true
+	return int(s.field_count), true
 }
 
 @(private = "package")

--- a/protobuf/wire/decoding.odin
+++ b/protobuf/wire/decoding.odin
@@ -52,9 +52,6 @@ decode_tag :: proc(buffer: []u8, index: ^int) -> (tag: Tag, ok: bool) {
 @(private = "file")
 decode_value :: proc(buffer: []u8, type: Type, index: ^int) -> (value: Value, ok: bool) {
 	switch type {
-		case .None:
-			fmt.eprintf("can't decode value when no type is provided\n")
-			return value, false
 		case .VARINT:
 			value = decode_varint(buffer, index) or_return
 			ok = true
@@ -73,6 +70,9 @@ decode_value :: proc(buffer: []u8, type: Type, index: ^int) -> (value: Value, ok
 			ok = true
 		case .SGROUP, .EGROUP:
 			fmt.eprintf("%v field type is deprecated\n", type)
+		case:
+			fmt.eprintf("can't decode value with unknown type %d\n", type)
+			return value, false
 	}
 
 	return value, ok

--- a/protobuf/wire/types.odin
+++ b/protobuf/wire/types.odin
@@ -1,13 +1,12 @@
 package protobuf_wire
 
 Type :: enum u32 {
-	None   = 0,
-	VARINT = 1, // int32, int64, uint32, uint64, sint32, sint64, bool, enum
-	I64    = 2, // fixed64, sfixed64, double
-	LEN    = 3, // string, bytes, embedded messages, packed repeated fields
-	SGROUP = 4, // group start (deprecated)
-	EGROUP = 5, // group end (deprecated)
-	I32    = 6, // fixed32, sfixed32, float
+	VARINT = 0, // int32, int64, uint32, uint64, sint32, sint64, bool, enum
+	I64    = 1, // fixed64, sfixed64, double
+	LEN    = 2, // string, bytes, embedded messages, packed repeated fields
+	SGROUP = 3, // group start (deprecated)
+	EGROUP = 4, // group end (deprecated)
+	I32    = 5, // fixed32, sfixed32, float
 }
 
 Tag :: struct {


### PR DESCRIPTION
Fixed wire format types to align with protobuf documentation.
  - Allows for encoding/decoding interoperability between C++ and Python serialized protobufs
Update to build with Odin dev-2024-12

