### PR TITLE
Update for PB 1.28.x+ and Odin dev-02-2025

### DIFF
--- a/protobuf/message/decoding.odin
+++ b/protobuf/message/decoding.odin
@@ -4,10 +4,16 @@ import "../builtins"
 import "../wire"
 
 import "base:runtime"
+import "core:slice"
 
-decode :: proc(message_tid: typeid, buffer: []u8) -> (message: any, ok: bool) {
-	message = new_scalar(message_tid) or_return
-	return message, decode_fill(message, buffer)
+decode :: proc($T: typeid, buffer: []u8) -> (message: ^T, ok: bool) {
+    msg, success := new_scalar(typeid_of(T))
+    if !success {
+        return nil, false
+    }
+
+    filled := decode_fill(msg, buffer)
+    return cast(^T)msg.data, filled
 }
 
 @(private = "file")

--- a/protobuf/message/encoding.odin
+++ b/protobuf/message/encoding.odin
@@ -12,21 +12,23 @@ encode :: proc(message: any) -> (buffer: []u8, ok: bool) {
 
     field_count := struct_field_count(message) or_return
 
-	for field_idx in 0 ..< field_count {
-		field_info := struct_field_info(message, field_idx) or_return
+    for field_idx in 0 ..< field_count {
+        field_info := struct_field_info(message, field_idx) or_return
+        wire_field: wire.Field
+        is_empty_repeated := false
 
-		wire_field: wire.Field
+        switch _ in field_info.type {
+        case Field_Type_Scalar:
+            wire_field = encode_field_scalar(field_info) or_return
+        case Field_Type_Repeated:
+            type_details := field_info.type.(Field_Type_Repeated)
+            is_empty_repeated = type_details.elem_size == 0
+            wire_field = encode_field_repeated(field_info) or_return
+        case Field_Type_Map:
+            wire_field = encode_field_map(field_info) or_return
+        }
 
-		switch _ in field_info.type {
-			case Field_Type_Scalar:
-				wire_field = encode_field_scalar(field_info) or_return
-			case Field_Type_Repeated:
-				wire_field = encode_field_repeated(field_info) or_return
-			case Field_Type_Map:
-				wire_field = encode_field_map(field_info) or_return
-		}
-
-        if check_is_empty(wire_field) {
+        if is_empty_repeated && check_is_empty(wire_field) {
             delete_key(&wire_message.fields, wire_field.tag.field_number)
             continue
         }
@@ -48,7 +50,13 @@ check_is_empty :: proc(f: wire.Field) -> bool {
     case wire.Type.I64:
         return f.values[0].(wire.Value_I64) == 0
     case wire.Type.LEN:
-        return len(f.values[0].(wire.Value_LEN)) == 0
+        for v in f.values {
+            if len(v.(wire.Value_LEN)) > 0 {
+                return false
+            }
+        }
+
+        return true
     case wire.Type.I32:
         return f.values[0].(wire.Value_I32) == 0
     case wire.Type.VARINT:

--- a/protobuf/message/encoding.odin
+++ b/protobuf/message/encoding.odin
@@ -117,7 +117,7 @@ encode_field_map :: proc(field_info: Field_Info) -> (field: wire.Field, ok: bool
 		allocator = context.temp_allocator,
 	)
 
-	entry_fields := make_map(
+	entry_fields := make_map_cap(
 		map[u32]wire.Field,
 		capacity = 2,
 		allocator = context.temp_allocator,

--- a/protobuf/message/encoding.odin
+++ b/protobuf/message/encoding.odin
@@ -10,8 +10,7 @@ encode :: proc(message: any) -> (buffer: []u8, ok: bool) {
 		fields = make_map(map[u32]wire.Field, allocator = context.temp_allocator),
 	}
 
-	field_count := struct_field_count(message) or_return
-    empty_fields := [dynamic]int{}
+    field_count := struct_field_count(message) or_return
 
 	for field_idx in 0 ..< field_count {
 		field_info := struct_field_info(message, field_idx) or_return
@@ -28,16 +27,12 @@ encode :: proc(message: any) -> (buffer: []u8, ok: bool) {
 		}
 
         if check_is_empty(wire_field) {
-            append(&empty_fields, field_idx)
+            delete_key(&wire_message.fields, wire_field.tag.field_number)
             continue
         }
 
 		wire_message.fields[wire_field.tag.field_number] = wire_field
 	}
-
-    for idx, _ in empty_fields {
-        delete_key(&wire_message.fields, u32(idx))
-    }
 
     return wire.encode(wire_message)
 }

--- a/protobuf/message/encoding.odin
+++ b/protobuf/message/encoding.odin
@@ -39,7 +39,11 @@ encode :: proc(message: any) -> (buffer: []u8, ok: bool) {
 
 @(private = "file")
 check_is_empty :: proc(f: wire.Field) -> bool {
-    // groups not supported, they are depreciated
+    if len(f.values) == 0 {
+        return true
+    }
+
+    // groups not supported
     #partial switch f.tag.type {
     case wire.Type.I64:
         return f.values[0].(wire.Value_I64) == 0

--- a/protobuf/message/types.odin
+++ b/protobuf/message/types.odin
@@ -151,9 +151,9 @@ is_packed :: proc(field_info: Field_Info) -> bool {
 
 @(private = "package")
 struct_field_count :: proc(message: any) -> (count: int, ok: bool) {
-	ti := runtime.type_info_base(type_info_of(message.id))
-	s := ti.variant.(runtime.Type_Info_Struct) or_return
-	return len(s.names), true
+    ti := runtime.type_info_base(type_info_of(message.id))
+    s := ti.variant.(runtime.Type_Info_Struct) or_return
+    return int(s.field_count), true
 }
 
 @(private = "package")

--- a/protobuf/wire/decoding.odin
+++ b/protobuf/wire/decoding.odin
@@ -52,9 +52,6 @@ decode_tag :: proc(buffer: []u8, index: ^int) -> (tag: Tag, ok: bool) {
 @(private = "file")
 decode_value :: proc(buffer: []u8, type: Type, index: ^int) -> (value: Value, ok: bool) {
 	switch type {
-		case .None:
-			fmt.eprintf("can't decode value when no type is provided\n")
-			return value, false
 		case .VARINT:
 			value = decode_varint(buffer, index) or_return
 			ok = true
@@ -73,6 +70,9 @@ decode_value :: proc(buffer: []u8, type: Type, index: ^int) -> (value: Value, ok
 			ok = true
 		case .SGROUP, .EGROUP:
 			fmt.eprintf("%v field type is deprecated\n", type)
+        case:
+            fmt.eprintf("can't decode value with unknown type %d\n", type)
+            return value, false
 	}
 
 	return value, ok

--- a/protobuf/wire/types.odin
+++ b/protobuf/wire/types.odin
@@ -1,13 +1,12 @@
 package protobuf_wire
 
-Type :: enum u32 {
-	None   = 0,
-	VARINT = 1, // int32, int64, uint32, uint64, sint32, sint64, bool, enum
-	I64    = 2, // fixed64, sfixed64, double
-	LEN    = 3, // string, bytes, embedded messages, packed repeated fields
-	SGROUP = 4, // group start (deprecated)
-	EGROUP = 5, // group end (deprecated)
-	I32    = 6, // fixed32, sfixed32, float
+Type :: enum u8 {
+	VARINT = 0, // int32, int64, uint32, uint64, sint32, sint64, bool, enum
+	I64    = 1, // fixed64, sfixed64, double
+	LEN    = 2, // string, bytes, embedded messages, packed repeated fields
+	SGROUP = 3, // group start (deprecated)
+	EGROUP = 4, // group end (deprecated)
+	I32    = 5, // fixed32, sfixed32, float
 }
 
 Tag :: struct {


### PR DESCRIPTION
Hey there!

Thank you for making this project, I implemented it and managed to fix all (currently known) issues I have had in my own project.

The changes in this PR will make the following changes:
- Make compatible with Odin dev-02-2025
- Fix Protobuf wire types
- Fix typed result when decoding
- Add wire message compacting

I have tested this against a Go server using Protobuf 1.28.1 (Proto3 syntax).
No changes to memory management yet.
